### PR TITLE
Add Docker support for production deployment

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,10 @@
+node_modules
+dist
+.git
+.github
+*.md
+!README.md
+.gitignore
+.nvmrc
+*.log
+data

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,41 @@
+# Multi-stage Dockerfile for engram
+# Production-ready: multi-stage build, non-root user, minimal image
+
+FROM node:22-alpine AS builder
+
+# Install build dependencies for native modules (better-sqlite3, sqlite-vec)
+RUN apk add --no-cache python3 make g++
+
+WORKDIR /build
+
+# Install dependencies first (better caching)
+COPY package*.json ./
+RUN npm ci --omit=dev
+
+# Copy source and build
+COPY . .
+RUN npm run build
+
+# Production stage
+FROM node:22-alpine
+
+# Install runtime dependencies for native modules
+RUN apk add --no-cache libstdc++
+
+# Create non-root user
+RUN addgroup -g 1001 engram && \
+    adduser -D -u 1001 -G engram engram
+
+WORKDIR /app
+
+# Copy built artifacts and dependencies from builder
+COPY --from=builder --chown=engram:engram /build/node_modules ./node_modules
+COPY --from=builder --chown=engram:engram /build/dist ./dist
+COPY --from=builder --chown=engram:engram /build/package*.json ./
+
+# Switch to non-root user
+USER engram
+
+# Default: run MCP server
+# Override CMD to run other binaries: docker run engram-mcp engram-init
+CMD ["node", "dist/bin/engram-mcp.js"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,22 @@
+services:
+  engram-mcp:
+    build: .
+    image: engram:latest
+    container_name: engram-mcp
+    restart: unless-stopped
+    volumes:
+      # Mount local directory for persistent memory storage
+      - ./data:/app/data
+    environment:
+      # Set OPENAI_API_KEY for embedding generation
+      - OPENAI_API_KEY=${OPENAI_API_KEY:-}
+    stdin_open: true
+    tty: true
+
+  # Example: Run tests in container
+  test:
+    build: .
+    image: engram:latest
+    command: npm test
+    volumes:
+      - ./tests:/app/tests


### PR DESCRIPTION
## Summary

Adds production-ready Docker configuration to engram:

- **Multi-stage Dockerfile** with Node 22 Alpine
- **Non-root user** (engram:1001) for security
- **Native dependency handling** (better-sqlite3, sqlite-vec build deps)
- **docker-compose.yml** for easy local development
- **.dockerignore** for optimized build context

## Testing

Default command runs `engram-mcp` server:
```bash
docker build -t engram .
docker run engram
```

Override for other binaries:
```bash
docker run engram node dist/bin/engram-init.js
```

Or use compose:
```bash
docker-compose up engram-mcp
docker-compose run test
```

Production-readiness artifact from Week 25 checklist.